### PR TITLE
fix: capitalization error

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -63,7 +63,7 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-        'api_version' => \App\Http\Middleware\APIversion::class,
+        'api_version' => \App\Http\Middleware\APIVersion::class,
         'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
         'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
         'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,


### PR DESCRIPTION
Fixes this error

```php
Illuminate\Contracts\Container\BindingResolutionException: Target class [App\Http\Middleware\APIversion] does not exist. in file /home/edqe/Projects/Gitlab/gkkb-server/vendor/laravel/framework/src/Illuminate/Container/Container.php on line 877
```